### PR TITLE
pulled main files into clean (coverage, mutation, random)

### DIFF
--- a/main_mutation.py
+++ b/main_mutation.py
@@ -37,6 +37,9 @@ parser.add_argument("--sensitive_index", help='The index for sensitive feature')
 parser.add_argument("--output", help='The name of output file', required=False)
 parser.add_argument("--time_out", help='Max. running time', default = 14400, required=False)
 parser.add_argument("--max_iter", help='The maximum number of iterations', default = 100000, required=False)
+parser.add_argument("--save_model", help='Enable save models', default = "False", required=False)
+parser.add_argument("--standard_scale", help='Preprocess data with standard scaling on features before using model', default = "False", required=False)
+parser.add_argument("--unaware", help='Mask the sensitive attribute (essentially running "fairness through unawareness"', default = "False", required=False)
 args = parser.parse_args()
 
 def check_for_fairness(X, y_pred, y_true, a, X_new = None, Y_new = None):
@@ -196,7 +199,23 @@ def test_cases(dataset, program_name, max_iter, X_train, X_test, y_train, y_test
                             newVal = inp[index] - abs(maxVal-minVal)/100
             print(inp)
 
-            res, LR, inp_valid, score, preds, features = input_program(inp, X_train, X_test, y_train, y_test, sensitive_param)
+            save_model = (args.save_model.lower()=="true")
+
+            mask = [False]*len(X_train[0])
+            if (args.unaware.lower()=="true"):
+                mask[sensitive_param-1] = True
+            X_train_masked = np.delete(X_train, mask, axis = 1)
+            X_test_masked = np.delete(X_test, mask, axis = 1)
+
+            if (args.standard_scale.lower()=="true"):
+                from sklearn.preprocessing import StandardScaler
+                    # To avoid "data leaking"/contaminating the testing data, we transform/fit the X_test data using the X_train data. 
+                ss = StandardScaler()
+                ss.fit(X_train_masked)
+                    
+                res, LR, inp_valid, score, preds, features = input_program(inp, ss.transform(X_train_masked), ss.transform(X_test_masked), y_train, y_test, sensitive_param, dataset_name=dataset, save_model=save_model)
+            else:
+                res, LR, inp_valid, score, preds, features = input_program(inp, X_train_masked, X_test_masked, y_train, y_test, sensitive_param, dataset_name=dataset, save_model=save_model)
 
             if not res:
                 failed += 1

--- a/main_random.py
+++ b/main_random.py
@@ -37,6 +37,10 @@ parser.add_argument("--output", help='The name of output file', required=False)
 parser.add_argument("--sensitive_index", help='The index for sensitive feature')
 parser.add_argument("--time_out", help='Max. running time', default = 14400, required=False)
 parser.add_argument("--max_iter", help='The maximum number of iterations', default = 100000, required=False)
+parser.add_argument("--save_model", help='Enable save models', default = "False", required=False)
+parser.add_argument("--standard_scale", help='Preprocess data with standard scaling on features before using model', default = "False", required=False)
+parser.add_argument("--unaware", help='Mask the sensitive attribute (essentially running "fairness through unawareness"', default = "False", required=False)
+
 args = parser.parse_args()
 
 def check_for_fairness(X, y_pred, y_true, a, X_new = None, Y_new = None):
@@ -157,8 +161,23 @@ def test_cases(dataset, program_name, max_iter, X_train, X_test, y_train, y_test
                         inp.append(np.random.uniform(minVal,maxVal+0.00001))
 
             print(inp)
+            
+            mask = [False]*len(X_train[0])
+            if (args.unaware.lower()=="true"):
+                mask[sensitive_param-1] = True
+            X_train_masked = np.delete(X_train, mask, axis = 1)
+            X_test_masked = np.delete(X_test, mask, axis = 1)
 
-            res, LR, inp_valid, score, preds, features = input_program(inp, X_train, X_test, y_train, y_test, sensitive_param)
+            save_model = (args.save_model.lower()=="true")
+            if (args.standard_scale.lower()=="true"):
+                from sklearn.preprocessing import StandardScaler
+                    # To avoid "data leaking"/contaminating the testing data, we transform/fit the X_test data using the X_train data. 
+                ss = StandardScaler()
+                ss.fit(X_train_masked)
+                    
+                res, LR, inp_valid, score, preds, features = input_program(inp, ss.transform(X_train_masked), ss.transform(X_test_masked), y_train, y_test, sensitive_param, dataset_name=dataset, save_model=save_model)
+            else:
+                res, LR, inp_valid, score, preds, features = input_program(inp, X_train_masked, X_test_masked, y_train, y_test, sensitive_param, dataset_name=dataset, save_model=save_model)
 
             if not res:
                 failed += 1


### PR DESCRIPTION
- Added flags to allow ability to save all models, standard scale the data points prior to training, and flag for a "fairness through unawareness" model. To use, add flag such as --standard_scale=True.

- Backwards compatible. Default is original (no saving models, standard scaling, nor fairness through unawareness).
- This feature is added for main_coverage, main_mutation, and main_random.